### PR TITLE
wrap link responses in trys

### DIFF
--- a/modules/bmo_cmds.py
+++ b/modules/bmo_cmds.py
@@ -153,7 +153,7 @@ def diarrama(phenny, input):
     # g = input.nick + ": " + input.groups()[1]
     # phenny.say(g)
     phenny.say('%s: *diarrhea' % input.nick)
-diarrama.rule = r'^(.*?)(\b[dD][rR][aA][mM][aA]\b)(.*)$'
+diarrama.rule = r'^(.*?)(\b(?i)drama\b)(.*)$'
 
 
 # tests for group(1) text

--- a/modules/link_shortener.py
+++ b/modules/link_shortener.py
@@ -1,5 +1,5 @@
-import requests
 import json
+import requests
 import os
     
 # Shortens a link via the google link shortener api
@@ -17,9 +17,12 @@ def link_shortener(phenny, input):
     headers = {'content-type': 'application/json' }
     
     response = requests.post(post_url,data=json.dumps(resource), headers=headers)
-    short_link = json.loads(response.text)['id']
-
-    phenny.say(short_link)
+    try:
+        short_link = str(response.json()['id'])
+        phenny.say(short_link)
+    except Exception as e:
+        error_msg = "{}: {}".format(e.__class__, e)
+        phenny.say("ARF!")
 
 link_shortener.rule = r'^(.*?)(https?://.+)\b(.*)$'
 


### PR DESCRIPTION
wraps the response in try block to swallow errors instead of displaying them inline.